### PR TITLE
temp: Release off of `cl/rocksdb-op-program`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: "Checkout monorepo"
           command: |
-            git clone https://github.com/ethereum-optimism/optimism
+            git clone https://github.com/ethereum-optimism/optimism -b cl/rocksdb-op-program
       - run:
           name: "Capture Data"
           command: |


### PR DESCRIPTION
## Overview

Temporary PR to release off of the https://github.com/ethereum-optimism/optimism/pull/11705 branch. That PR changes the witness database format, and the chain-test-data is required to get CI passing.